### PR TITLE
README.md: Correct installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Read more about [SUIT's design principles](https://github.com/suitcss/suit/).
 
 ## Installation
 
-* [Component(1)](http://component.io/): `component install suitcss/flex-embed`
+* [Component(1)](http://component.io/): `component install suitcss/components-flex-embed`
 * [npm](https://www.npmjs.org/package/suitcss-components-flex-embed): `npm install suitcss-components-flex-embed`
 * [Bower](http://bower.io/): `bower install suit-flex-embed`
 * Download: [zip](https://github.com/suitcss/flex-embed/zipball/master)


### PR DESCRIPTION
Using `component install suitcss/flex-embed` will result in:

![](https://cloud.githubusercontent.com/assets/1223565/2975804/0f0a256c-db99-11e3-9aea-d1489eee0e76.png)
