### PR TITLE
Allow aspect ratios to be calculated programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Alternatively, aspect ratios can be calculated programmatically and the
 corresponding `padding-bottom` value applied using an inline style.
 
 ```html
-<div class="FlexEmbed" style="padding-bottom:{{percentage}}%">
+<div class="FlexEmbed FlexEmbed--custom" style="padding-bottom:{{percentage}}%">
   [iframe|object|embed]
 </div>
 ```

--- a/lib/flex-embed.css
+++ b/lib/flex-embed.css
@@ -71,6 +71,14 @@
 }
 
 /**
+ * Custom modifier: allow aspect ratio via inline style
+ */
+
+.FlexEmbed--custom:before {
+  padding-bottom: 0;
+}
+
+/**
  * Works automatically for iframes, embeds, and objects to account for
  * situations where you cannot modify the enbedded element's attributes (e.g.,
  * 3rd party widget code).

--- a/test/index.html
+++ b/test/index.html
@@ -101,4 +101,18 @@
       <img class="FlexEmbed-item" width="500" height="375" src="http://lorempixel.com/500/375/nature/9" alt="">
     </div>
   </div>
+
+  <h2 class="Test-describe">.FlexEmbed--custom</h2>
+  <h3 class="Test-it">custom render (iframe), 3:1 via inline style</h3>
+  <div class="Test-run">
+    <div class="FlexEmbed FlexEmbed--custom" style="padding-bottom: 33.3333%">
+      <iframe width="1200" height="400" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+    </div>
+  </div>
+  <h3 class="Test-it">custom render (img), 3:1 via inline style</h3>
+  <div class="Test-run">
+    <div class="FlexEmbed FlexEmbed--custom" style="padding-bottom: 33.3333%">
+      <img class="FlexEmbed-item" width="600" height="200" src="http://lorempixel.com/600/200/nature/9" alt="">
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
The current example in the README is not working because the default
ration is 1:1. Using inline style just add the ratio to the 1:1. It’s
not what you want to do.
This simple `--custom` modifier allow that.
