### PR TITLE
Fix dynamic aspect ratio support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 === HEAD
 
+* No longer affects the styles of child images / embeds.
+* Fix dynamic aspect ratio support.
+
 === 1.7.1 (June 24, 2014)
 
 * Add `.css` extension to imports for interoperability.

--- a/README.md
+++ b/README.md
@@ -14,25 +14,24 @@ Read more about [SUIT CSS's design principles](https://github.com/suitcss/suit/)
 
 ## Available classes
 
-* `FlexEmbed` - The core, responsive-embed component with 1:1 aspect ratio
-* `FlexEmbed--3by1` - The modifier class for 3:1 aspect ratio embed
-* `FlexEmbed--2by1` - The modifier class for 2:1 aspect ratio embed
-* `FlexEmbed--16by9` - The modifier class for 16:9 aspect ratio embed
-* `FlexEmbed--4by3` - The modifier class for 4:3 aspect ratio embed
-* `FlexEmbed-item` - The descendent class for the media that is being embedded
-  (optional for `iframe`, `embed`, and `object` elements)
+* `FlexEmbed` - The root node.
+* `FlexEmbed-ratio` - The element that provides the aspect ratio (1:1 by default).
+* `FlexEmbed-ratio--3by1` - The modifier class for 3:1 aspect ratio embed.
+* `FlexEmbed-ratio--2by1` - The modifier class for 2:1 aspect ratio embed,
+* `FlexEmbed-ratio--16by9` - The modifier class for 16:9 aspect ratio embed.
+* `FlexEmbed-ratio--4by3` - The modifier class for 4:3 aspect ratio embed.
+* `FlexEmbed-content` - The descendent class for the content that is being displayed.
 
 ## Usage
 
-Examples:
+Example:
 
 ```html
-<div class="FlexEmbed FlexEmbed--16by9">
-  [iframe|object|embed]
-</div>
-
-<div class="FlexEmbed FlexEmbed--4by3">
-  <img class="FlexEmbed-item" src="…" alt="">
+<div class="FlexEmbed">
+  <div class="FlexEmbed-ratio FlexEmbed-ratio--16by9"></div>
+  <div class="FlexEmbed-content">
+    <!-- child content -->
+  </div>
 </div>
 ```
 
@@ -44,7 +43,7 @@ ratio:
  * Modifier: 47:20 aspect ratio
  */
 
-.FlexEmbed--47by20:before {
+.FlexEmbed-ratio--47by20 {
   padding-bottom: 42.55%;
 }
 ```
@@ -53,8 +52,11 @@ Alternatively, aspect ratios can be calculated programmatically and the
 corresponding `padding-bottom` value applied using an inline style.
 
 ```html
-<div class="FlexEmbed" style="padding-bottom:{{percentage}}%">
-  [iframe|object|embed]
+<div class="FlexEmbed">
+  <div class="FlexEmbed-ratio" style="padding-bottom:{{percentage}}%"></div>
+  <div class="FlexEmbed-content">
+    <!-- child content -->
+  </div>
 </div>
 ```
 

--- a/lib/flex-embed.css
+++ b/lib/flex-embed.css
@@ -7,16 +7,6 @@
  * that need to retain a specific aspect ratio but adapt to the width of their
  * containing element.
  *
- * Example HTML:
- *
- * <div class="FlexEmbed FlexEmbed--4by3">
- *   <iframe class="FlexEmbed-item" src="…"></iframe>
- * </div>
- *
- * <div class="FlexEmbed FlexEmbed--16by9">
- *   [iframe|object|embed]
- * </div>
- *
  * Based on: http://alistapart.com/article/creating-intrinsic-ratios-for-video
  */
 
@@ -27,12 +17,11 @@
 }
 
 /**
- * The aspect-ratio hack is applied to a pseudo-element because it allows the
- * component to respect `max-height`. Default aspect ratio is 1:1.
+ * The aspect-ratio hack is applied to an empty element because it allows
+ * the component to respect `max-height`. Default aspect ratio is 1:1.
  */
 
-.FlexEmbed:before {
-  content: "";
+.FlexEmbed-ratio {
   display: block;
   padding-bottom: 100%;
   width: 100%;
@@ -42,7 +31,7 @@
  * Modifier: 3:1 aspect ratio
  */
 
-.FlexEmbed--3by1:before {
+.FlexEmbed-ratio--3by1 {
   padding-bottom: calc(100% / 3);
 }
 
@@ -50,7 +39,7 @@
  * Modifier: 2:1 aspect ratio
  */
 
-.FlexEmbed--2by1:before {
+.FlexEmbed-ratio--2by1 {
   padding-bottom: 50%;
 }
 
@@ -58,7 +47,7 @@
  * Modifier: 16:9 aspect ratio
  */
 
-.FlexEmbed--16by9:before {
+.FlexEmbed-ratio--16by9 {
   padding-bottom: 56.25%;
 }
 
@@ -66,20 +55,15 @@
  * Modifier: 4:3 aspect ratio
  */
 
-.FlexEmbed--4by3:before {
+.FlexEmbed-ratio--4by3 {
   padding-bottom: 75%;
 }
 
 /**
- * Works automatically for iframes, embeds, and objects to account for
- * situations where you cannot modify the enbedded element's attributes (e.g.,
- * 3rd party widget code).
+ * Fit the content to the aspect ratio
  */
 
-.FlexEmbed-item,
-.FlexEmbed iframe,
-.FlexEmbed embed,
-.FlexEmbed object {
+.FlexEmbed-content {
   bottom: 0;
   height: 100%;
   left: 0;

--- a/test/index.html
+++ b/test/index.html
@@ -8,6 +8,16 @@
     max-width: 500px;
   }
 
+  .Test-run img {
+    height: auto;
+    max-width: 100%;
+  }
+
+  .Test-run iframe {
+    height: 100%;
+    width: 100%;
+  }
+
   #max-height .FlexEmbed {
     max-height: 200px;
   }
@@ -18,87 +28,132 @@
 </style>
 
 <div class="Test">
-  <h1 class="Test-title">SUIT CSS: <a href="https://github.com/suitcss/flex-embed">FlexEmbed</a> component tests</h1>
+  <h1 class="Test-title">SUIT CSS: <a href="https://github.com/suitcss/components-flex-embed">FlexEmbed</a> component tests</h1>
 
   <h2 class="Test-describe">.FlexEmbed</h2>
   <h3 class="Test-it">renders 1:1 (iframe)</h3>
   <div class="Test-run">
     <div class="FlexEmbed">
-      <iframe width="1200" height="1200" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+      <div class="FlexEmbed-ratio"></div>
+      <div class="FlexEmbed-content">
+        <iframe width="1200" height="1200" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+      </div>
     </div>
   </div>
   <h3 class="Test-it">renders 1:1 (img)</h3>
   <div class="Test-run">
     <div class="FlexEmbed">
-      <img class="FlexEmbed-item" width="600" height="600" src="http://lorempixel.com/600/600/nature/9" alt="">
+      <div class="FlexEmbed-ratio"></div>
+      <div class="FlexEmbed-content">
+        <img width="600" height="600" src="http://lorempixel.com/600/600/nature/9" alt="">
+      </div>
+    </div>
+  </div>
+  <h3 class="Test-it">support dynamic ratios</h3>
+  <div class="Test-run">
+    <div class="FlexEmbed">
+      <div class="FlexEmbed-ratio" style="padding-bottom:50%"></div>
+      <div class="FlexEmbed-content">
+        <iframe width="1280" height="1280" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+      </div>
     </div>
   </div>
   <h3 class="Test-it">supports max-height</h3>
   <div class="Test-run" id="max-height">
     <div class="FlexEmbed">
-      <iframe width="1280" height="1280" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+      <div class="FlexEmbed-ratio"></div>
+      <div class="FlexEmbed-content">
+        <iframe width="1280" height="1280" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+      </div>
     </div>
   </div>
   <h3 class="Test-it">supports max-width</h3>
   <div class="Test-run" id="max-width">
     <div class="FlexEmbed">
-      <iframe width="1280" height="1280" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+      <div class="FlexEmbed-ratio"></div>
+      <div class="FlexEmbed-content">
+        <iframe width="1280" height="1280" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+      </div>
     </div>
   </div>
 
-  <h2 class="Test-describe">.FlexEmbed--3by1</h2>
+  <h2 class="Test-describe">.FlexEmbed-ratio--3by1</h2>
   <h3 class="Test-it">renders 3:1 (iframe)</h3>
   <div class="Test-run">
-    <div class="FlexEmbed FlexEmbed--3by1">
-      <iframe width="1200" height="400" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+    <div class="FlexEmbed">
+      <div class="FlexEmbed-ratio FlexEmbed-ratio--3by1"></div>
+      <div class="FlexEmbed-content">
+        <iframe width="1200" height="400" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+      </div>
     </div>
   </div>
   <h3 class="Test-it">renders 3:1 (img)</h3>
   <div class="Test-run">
-    <div class="FlexEmbed FlexEmbed--3by1">
-      <img class="FlexEmbed-item" width="600" height="200" src="http://lorempixel.com/600/200/nature/9" alt="">
+    <div class="FlexEmbed">
+      <div class="FlexEmbed-ratio FlexEmbed-ratio--3by1"></div>
+      <div class="FlexEmbed-content">
+        <img width="600" height="200" src="http://lorempixel.com/600/200/nature/9" alt="">
+      </div>
     </div>
   </div>
 
-  <h2 class="Test-describe">.FlexEmbed--2by1</h2>
+  <h2 class="Test-describe">.FlexEmbed-ratio--2by1</h2>
   <h3 class="Test-it">renders 2:1 (iframe)</h3>
   <div class="Test-run">
-    <div class="FlexEmbed FlexEmbed--2by1">
-      <iframe width="1200" height="600" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+    <div class="FlexEmbed">
+      <div class="FlexEmbed-ratio FlexEmbed-ratio--2by1"></div>
+      <div class="FlexEmbed-content">
+        <iframe width="1200" height="600" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+      </div>
     </div>
   </div>
   <h3 class="Test-it">renders 2:1 (img)</h3>
   <div class="Test-run">
-    <div class="FlexEmbed FlexEmbed--2by1">
-      <img class="FlexEmbed-item" width="600" height="300" src="http://lorempixel.com/600/300/nature/9" alt="">
+    <div class="FlexEmbed">
+      <div class="FlexEmbed-ratio FlexEmbed-ratio--2by1"></div>
+      <div class="FlexEmbed-content">
+        <img width="600" height="300" src="http://lorempixel.com/600/300/nature/9" alt="">
+      </div>
     </div>
   </div>
 
-  <h2 class="Test-describe">.FlexEmbed--16by9</h2>
+  <h2 class="Test-describe">.FlexEmbed-ratio--16by9</h2>
   <h3 class="Test-it">renders 16:9 (iframe)</h3>
   <div class="Test-run">
-    <div class="FlexEmbed FlexEmbed--16by9">
-      <iframe width="1280" height="720" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+    <div class="FlexEmbed">
+      <div class="FlexEmbed-ratio FlexEmbed-ratio--16by9"></div>
+      <div class="FlexEmbed-content">
+        <iframe width="1280" height="720" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+      </div>
     </div>
   </div>
   <h3 class="Test-it">renders 16:9 (img)</h3>
   <div class="Test-run">
-    <div class="FlexEmbed FlexEmbed--16by9">
-      <img class="FlexEmbed-item" width="500" height="280" src="http://lorempixel.com/500/280/nature/9" alt="">
+    <div class="FlexEmbed">
+      <div class="FlexEmbed-ratio FlexEmbed-ratio--16by9"></div>
+      <div class="FlexEmbed-content">
+        <img width="500" height="280" src="http://lorempixel.com/500/280/nature/9" alt="">
+      </div>
     </div>
   </div>
 
-  <h2 class="Test-describe">.FlexEmbed--4by3</h2>
+  <h2 class="Test-describe">.FlexEmbed-ratio--4by3</h2>
   <h3 class="Test-it">renders 4:3 (iframe)</h3>
   <div class="Test-run">
-    <div class="FlexEmbed FlexEmbed--4by3">
-      <iframe width="1280" height="720" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+    <div class="FlexEmbed">
+      <div class="FlexEmbed-ratio FlexEmbed-ratio--4by3"></div>
+      <div class="FlexEmbed-content">
+        <iframe width="1280" height="720" src="http://www.youtube.com/embed/BOOljk_LOcs" frameborder="0" allowfullscreen></iframe>
+      </div>
     </div>
   </div>
   <h3 class="Test-it">renders 4:3 (img)</h3>
   <div class="Test-run">
-    <div class="FlexEmbed FlexEmbed--4by3">
-      <img class="FlexEmbed-item" width="500" height="375" src="http://lorempixel.com/500/375/nature/9" alt="">
+    <div class="FlexEmbed">
+      <div class="FlexEmbed-ratio FlexEmbed-ratio--4by3"></div>
+      <div class="FlexEmbed-content">
+        <img width="500" height="375" src="http://lorempixel.com/500/375/nature/9" alt="">
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Moving the responsibility for the correct aspect ratio to a pseudo-element broke the ability to dynamically set the ratio via inline styles. This change uses an empty element rather than a pseudo-element.
